### PR TITLE
Rename compose files to .yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__/
 .env
-compose.override.yml
+compose.override.yaml
 router/config.toml
 .tmp/
 tmp/

--- a/AGENTS-developer.md.example
+++ b/AGENTS-developer.md.example
@@ -20,7 +20,7 @@ suisou-template baseline.
 ## Build and run
 
 Any derived-project-specific build flags, GPU configuration, volumes,
-etc. that aren't already obvious from `compose.yml`.
+etc. that aren't already obvious from `compose.yaml`.
 
 ## Testing the application
 

--- a/AGENTS-suisou.md
+++ b/AGENTS-suisou.md
@@ -24,7 +24,7 @@ code (agents, custom nodes, plugins).  The goals are:
 
 ## Services
 
-A suisou stack has three services, defined in `compose.yml`.
+A suisou stack has three services, defined in `compose.yaml`.
 
 ### `app` (sandbox)
 
@@ -145,7 +145,7 @@ The following are the security boundary.  Never edit them locally; any
 bug fix or feature must flow through the `suisou-template` repository so
 it applies to every derived project.
 
-- `compose.yml` (base service definitions; customize via `compose.override.yml`)
+- `compose.yaml` (base service definitions; customize via `compose.override.yaml`)
 - `router/Dockerfile`
 - `router/addon.py`
 - `wg-client/Dockerfile`
@@ -160,7 +160,7 @@ These exist in the template as placeholders or examples and are expected
 to be rewritten in each derived project:
 
 - `sandbox/Dockerfile` — replaced with the application's image.
-- `compose.override.yml` — app-specific overrides: build context, volumes,
+- `compose.override.yaml` — app-specific overrides: build context, volumes,
   ports, and credential injection.  Never committed (contains or references
   secrets).
 - `router/config.toml` — copied from `config.example.toml` and edited to
@@ -204,7 +204,7 @@ derived project:
 git remote add template https://github.com/gyu-don/suisou-template.git
 git fetch template
 git checkout template/main -- \
-    compose.yml \
+    compose.yaml \
     router/Dockerfile router/addon.py \
     wg-client/Dockerfile wg-client/entrypoint.sh \
     sandbox/entrypoint.sh \

--- a/AGENTS-template.md
+++ b/AGENTS-template.md
@@ -27,8 +27,8 @@ rm -rf examples/
 
 ## 3. Replace placeholders
 
-The base `compose.yml` is fixed and should not be modified.  All
-app-specific configuration goes in `compose.override.yml`.
+The base `compose.yaml` is fixed and should not be modified.  All
+app-specific configuration goes in `compose.override.yaml`.
 
 Copy from an example if one exists:
 
@@ -36,10 +36,10 @@ Copy from an example if one exists:
 # Example: ComfyUI
 cp examples/comfyui/sandbox/Dockerfile sandbox/Dockerfile
 cp examples/comfyui/router/config.toml router/config.toml
-cp examples/comfyui/compose.override.yml compose.override.yml
+cp examples/comfyui/compose.override.yaml compose.override.yaml
 ```
 
-Then edit `compose.override.yml` to adjust paths (change
+Then edit `compose.override.yaml` to adjust paths (change
 `examples/comfyui/...` to `./...`):
 
 ```yaml
@@ -68,12 +68,12 @@ If no matching example exists:
   `ENTRYPOINT ["suisou-entrypoint.sh"]` line.
 - `router/config.toml` — copy from `router/config.example.toml` and
   enable only the services your application needs.
-- `compose.override.yml` — copy from `compose.override.example.yml`
+- `compose.override.yaml` — copy from `compose.override.example.yaml`
   and customize build context, volumes, and ports.
 
 ## 4. Wire up credentials
 
-Add credential injection to `compose.override.yml`:
+Add credential injection to `compose.override.yaml`:
 
 ```yaml
 services:

--- a/AGENTS-user.md.example
+++ b/AGENTS-user.md.example
@@ -19,10 +19,10 @@ to the upstream application's documentation.
 
 ```sh
 cp router/config.example.toml router/config.toml
-cp compose.override.example.yml compose.override.yml
+cp compose.override.example.yaml compose.override.yaml
 # edit both files as needed
-docker compose -f compose.yml -f compose.override.yml build
-docker compose -f compose.yml -f compose.override.yml up
+docker compose -f compose.yaml -f compose.override.yaml build
+docker compose -f compose.yaml -f compose.override.yaml up
 ```
 
 ## Configuration
@@ -32,7 +32,7 @@ docker compose -f compose.yml -f compose.override.yml up
 List the `[services.<name>]` blocks this application actually needs and
 briefly explain why.
 
-### `compose.override.yml`
+### `compose.override.yaml`
 
 List the `SUISOU__<ENV>` markers this application uses and which service
 each one authenticates against.  Reference `AGENTS-suisou.md` for the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This is the template repository for building a [suisou](https://github.com/gyu-don/suisou)
 sandbox around a specific application.  It is not itself a runnable
 sandbox — use the **Use this template** button on GitHub to create a new
-repository, then replace the placeholder `sandbox/` and `compose.yml`
+repository, then replace the placeholder `sandbox/` and `compose.yaml`
 `app` service with your application.
 
 The core mechanics (router, wg-client, credential injection, allowlist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ that every derived project starts from.  Specifically:
 
 - `router/` and `wg-client/`: the enforcement layer.
 - `sandbox/entrypoint.sh`: the CA-install and DNS-setup glue.
-- `sandbox/Dockerfile` and `compose.yml`: placeholders that every
+- `sandbox/Dockerfile` and `compose.yaml`: placeholders that every
   derived project rewrites.  Changes here should keep them small and
   unopinionated.
 - `router/config.example.toml`: a menu of common allowlist services;
@@ -46,7 +46,7 @@ What does **not** belong here:
 - Application-specific sandbox images (those live in derived projects,
   with a reference copy under `examples/`).
 - Project-specific `router/config.toml` (derived-project concern).
-- Personal credentials or `compose.override.yml`.
+- Personal credentials or `compose.override.yaml`.
 
 ## Security-critical changes
 
@@ -76,7 +76,7 @@ them.
 
 `examples/<app>/` should build against the current `router/` and
 `wg-client/` and should pass the verification checklist.  When you
-change the placeholder `sandbox/Dockerfile` or `compose.yml`, make the
+change the placeholder `sandbox/Dockerfile` or `compose.yaml`, make the
 analogous change in each example so that a user who copies from
 `examples/` ends up with a working sandbox on the first try.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ exfiltrating data or credentials.
 1. Click **Use this template → Create a new repository** on GitHub.
 2. Clone the new repository and follow the step-by-step guide in
    [AGENTS-template.md](AGENTS-template.md).
-3. Keep `compose.yml`, `router/`, `wg-client/`, `sandbox/entrypoint.sh`, and
+3. Keep `compose.yaml`, `router/`, `wg-client/`, `sandbox/entrypoint.sh`, and
    `AGENTS-suisou.md` unmodified in your derived project — they are the
    security boundary and are kept in sync with this template.
 
@@ -25,7 +25,7 @@ Existing implementations:
 Run an example from the repo root:
 
 ```sh
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml up
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml up
 ```
 
 ## Contributing to the template itself

--- a/compose.override.example.yaml
+++ b/compose.override.example.yaml
@@ -1,5 +1,5 @@
-# compose.override.yml — project-specific overrides (auto-merged with compose.yml)
-# Copy this file to compose.override.yml and edit as needed.
+# compose.override.yaml — project-specific overrides (auto-merged with compose.yaml)
+# Copy this file to compose.override.yaml and edit as needed.
 #
 # Credential injection:
 #   app.environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,12 +1,12 @@
-# Suisou base compose.yml — fixed structure, do not modify.
+# Suisou base compose.yaml — fixed structure, do not modify.
 #
-# Customize via compose.override.yml:
+# Customize via compose.override.yaml:
 #   - app: build context, volumes
 #   - wg-client: ports
 #   - router: environment (for credential injection)
 #
 # Run: docker compose up
-# With example: docker compose -f compose.yml -f examples/X/compose.override.yml up
+# With example: docker compose -f compose.yaml -f examples/X/compose.override.yaml up
 
 services:
   app:

--- a/examples/comfyui/AGENTS-developer.md
+++ b/examples/comfyui/AGENTS-developer.md
@@ -7,11 +7,11 @@ English for all code, configuration, and documentation.
 ## Verification
 
 ```sh
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml config -q
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml build
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml up -d
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml ps
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml logs router --tail=20
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml config -q
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml build
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml up -d
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml ps
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml logs router --tail=20
 ```
 
 For routing/credential changes, run the full verification checklist in AGENTS-suisou.md.
@@ -19,7 +19,7 @@ For routing/credential changes, run the full verification checklist in AGENTS-su
 ## Project Layout
 
 ```
-compose.override.yml     # App-specific overrides (build, volumes, ports)
+compose.override.yaml    # App-specific overrides (build, volumes, ports)
 sandbox/Dockerfile       # ComfyUI image
-router/config.toml       # Allowlist (GitHub, registry.comfy.org, PyPI, uv)
+router/config.toml       # Allowlist (GitHub, registry.comfy.org, PyPI, uv, optional model/package hosts)
 ```

--- a/examples/comfyui/AGENTS-user.md
+++ b/examples/comfyui/AGENTS-user.md
@@ -11,14 +11,14 @@ ComfyUI docs: <https://docs.comfy.org/>
 ## Quick Start
 
 ```sh
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml up
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml up
 ```
 
 Open <http://localhost:8188/>.
 
 ## GPU Acceleration
 
-Uncomment the `deploy` section in `compose.override.yml`:
+Uncomment the `deploy` section in `compose.override.yaml`:
 
 ```yaml
 services:
@@ -34,9 +34,15 @@ services:
 
 Requires [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
+## Storage
+
+The example override mounts a named volume at `/app`, so the bundled ComfyUI checkout, custom nodes, downloaded models, and generated outputs persist across rebuilds.
+
 ## Custom Nodes
 
 Use the ComfyUI-Manager panel (Manager > Custom Nodes Manager). Nodes are fetched from GitHub via the ComfyUI Registry; Python deps from PyPI.
+
+Some custom nodes install PyTorch or NVIDIA Python wheels from extra package indexes. If needed, uncomment the optional `download*.pytorch.org` and `pypi.nvidia.com` entries in `router/config.toml`.
 
 ## Model Downloads
 
@@ -51,7 +57,7 @@ endpoints = [
 ]
 ```
 
-For gated models, add credential injection in `compose.override.yml`:
+For gated models, add credential injection in `compose.override.yaml`:
 
 ```yaml
 services:
@@ -62,6 +68,8 @@ services:
     environment:
       - HUGGING_FACE_HUB_TOKEN
 ```
+
+Provide real secrets from your shell or a secrets manager at runtime. Do not commit them to `compose.override.yaml`.
 
 ## Remote Access
 

--- a/examples/comfyui/AGENTS.md
+++ b/examples/comfyui/AGENTS.md
@@ -9,6 +9,7 @@ A Docker Compose-based sandbox environment for [ComfyUI](https://www.comfy.org/)
 - **router** — mitmproxy in WireGuard mode. Enforces domain allowlist (`router/config.toml`) and credential injection.
 
 Default allowlist: GitHub (read-only), `registry.comfy.org`, PyPI, `astral.sh`. Model hosting is commented out.
+The example `compose.override.yaml` exposes port `8188` and persists `/app` in a named volume.
 
 ## Documentation
 

--- a/examples/comfyui/README.md
+++ b/examples/comfyui/README.md
@@ -8,10 +8,12 @@ A Docker Compose sandbox for [ComfyUI](https://www.comfy.org/) with controlled n
 
 ```sh
 # From repository root
-docker compose -f compose.yml -f examples/comfyui/compose.override.yml up
+docker compose -f compose.yaml -f examples/comfyui/compose.override.yaml up
 ```
 
 Open http://localhost:8188/.
+
+The example override publishes port `8188` and persists `/app` in a Docker volume so custom nodes, models, and outputs survive container rebuilds.
 
 ## Documentation
 

--- a/examples/comfyui/router/config.toml
+++ b/examples/comfyui/router/config.toml
@@ -10,7 +10,7 @@
 # --- GitHub ---
 # Custom node repositories and dependency sources hosted on GitHub.
 # POST is restricted to git-upload-pack (clone/fetch) so push is blocked.
-[services.github-git]
+[services.github]
 endpoints = [
   { domain = "github.com",             methods = ["GET"] },
   { domain = "github.com",             methods = ["POST"], paths = ["/*/git-upload-pack"] },
@@ -26,11 +26,13 @@ endpoints = [
 ]
 
 # --- Python packages ---
-# pip and uv download packages from PyPI.
-[services.pypi]
+# pip and uv download packages from PyPI, PyTorch, NVIDIA.
+[services.pip]
 endpoints = [
   { domain = "pypi.org",               methods = ["GET"] },
   { domain = "files.pythonhosted.org", methods = ["GET"] },
+  { domain = "download*.pytorch.org", methods = ["GET"] },
+  { domain = "pypi.nvidia.com",       methods = ["GET"] },
 ]
 
 # --- uv ---
@@ -40,6 +42,14 @@ endpoints = [
   { domain = "astral.sh",   methods = ["GET"] },
   { domain = "*.astral.sh", methods = ["GET"] },
 ]
+
+# --- apt repositories ---
+# Uncomment to allow downloading packages from apt at runtime.
+# [services.apt]
+# endpoints = [
+#   { domain = "ports.ubuntu.com", methods = ["GET", "POST"], allow_plain_http = true },
+#   { domain = "developer.download.nvidia.com", methods = ["GET", "POST"] },
+# ]
 
 # --- Model hosting ---
 # Uncomment to allow downloading models at runtime.

--- a/examples/open-webui/AGENTS-developer.md
+++ b/examples/open-webui/AGENTS-developer.md
@@ -7,11 +7,11 @@ English for all code, configuration, and documentation.
 ## Verification
 
 ```sh
-docker compose -f compose.yml -f examples/open-webui/compose.override.yml config -q
-docker compose -f compose.yml -f examples/open-webui/compose.override.yml build
-docker compose -f compose.yml -f examples/open-webui/compose.override.yml up -d
-docker compose -f compose.yml -f examples/open-webui/compose.override.yml ps
-docker compose -f compose.yml -f examples/open-webui/compose.override.yml logs router --tail=20
+docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml config -q
+docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml build
+docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml up -d
+docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml ps
+docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml logs router --tail=20
 ```
 
 For routing/credential changes, run the full verification checklist in AGENTS-suisou.md.
@@ -19,7 +19,7 @@ For routing/credential changes, run the full verification checklist in AGENTS-su
 ## Project Layout
 
 ```
-compose.override.yml     # App-specific overrides (build, volumes, ports)
+compose.override.yaml    # App-specific overrides (build, volumes, ports)
 sandbox/Dockerfile       # Open WebUI image
 router/config.toml       # Allowlist
 ```

--- a/examples/open-webui/AGENTS-user.md
+++ b/examples/open-webui/AGENTS-user.md
@@ -10,7 +10,7 @@ Open WebUI docs: <https://docs.openwebui.com/>
 ## Quick Start
 
 ```sh
-docker compose -f compose.yml -f examples/open-webui/compose.override.yml up
+docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml up
 ```
 
 Open <http://localhost:3000/>.
@@ -23,10 +23,10 @@ Controls which domains the agent can access and how credentials are injected. Ed
 
 ### Credential injection
 
-The router uses a naming convention to replace dummy credentials with real ones. This requires settings in two places — `compose.override.yml` configures both together:
+The router uses a naming convention to replace dummy credentials with real ones. This requires settings in two places — `compose.override.yaml` configures both together:
 
 ```yaml
-# compose.override.yml
+# compose.override.yaml
 services:
   app:
     environment:
@@ -63,23 +63,23 @@ doppler secrets set ANTHROPIC_API_KEY=sk-ant-...
 #### Running with secrets injected
 
 ```sh
-doppler run -- docker compose -f compose.yml -f examples/open-webui/compose.override.yml up
+doppler run -- docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml up
 ```
 
 If you need to specify a project or config explicitly (e.g. in CI):
 
 ```sh
-doppler run -p PROJECT -c CONFIG -- docker compose -f compose.yml -f examples/open-webui/compose.override.yml up
+doppler run -p PROJECT -c CONFIG -- docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml up
 ```
 
 #### Other options
 
 ```sh
 # 1Password CLI
-op run --env-file=.env -- docker compose -f compose.yml -f examples/open-webui/compose.override.yml up
+op run --env-file=.env -- docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml up
 ```
 
-Passing secrets inline (e.g. `ANTHROPIC_API_KEY=sk-ant-... docker compose -f compose.yml -f examples/open-webui/compose.override.yml up`) is not recommended — the value ends up in shell history and, if run through an AI agent, in its session context as well.
+Passing secrets inline (e.g. `ANTHROPIC_API_KEY=sk-ant-... docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml up`) is not recommended — the value ends up in shell history and, if run through an AI agent, in its session context as well.
 
 ## Remote Access
 
@@ -127,7 +127,7 @@ Set `MOLTBOOK_API_KEY` to the value returned in step 1, using whichever method y
 
 **Step 4 — Configure credential injection**
 
-Add to `compose.override.yml`:
+Add to `compose.override.yaml`:
 
 ```yaml
 services:
@@ -166,7 +166,7 @@ Set `DISCORD_BOT_TOKEN` to the token from the Developer Portal, using whichever 
 
 **Step 3 — Configure credential injection**
 
-Add to `compose.override.yml`:
+Add to `compose.override.yaml`:
 
 ```yaml
 services:

--- a/examples/open-webui/README.md
+++ b/examples/open-webui/README.md
@@ -8,7 +8,7 @@ The router (mitmproxy) enforces a domain allowlist and transparently injects sec
 
 ```sh
 # From repository root
-docker compose -f compose.yml -f examples/open-webui/compose.override.yml up
+docker compose -f compose.yaml -f examples/open-webui/compose.override.yaml up
 ```
 
 Open http://localhost:3000/.

--- a/examples/open-webui/router/config.toml
+++ b/examples/open-webui/router/config.toml
@@ -80,7 +80,7 @@ endpoints = [
 # env = "TAVILY_API_KEY"
 
 # --- Local LLM ---
-# For a local LLM instance on the host (configure it in compose.override.yml).
+# For a local LLM instance on the host (configure it in compose.override.yaml).
 # Uncomment the block matching your server and its default port.
 #
 # [services.ollama]

--- a/router/config.example.toml
+++ b/router/config.example.toml
@@ -80,7 +80,7 @@ endpoints = [
 # env = "TAVILY_API_KEY"
 
 # --- Local LLM ---
-# For a local LLM instance on the host (configure it in compose.override.yml).
+# For a local LLM instance on the host (configure it in compose.override.yaml).
 # Uncomment the block matching your server and its default port.
 #
 # [services.ollama]


### PR DESCRIPTION
## Summary
- rename the base compose file from `.yml` to `.yaml`
- rename example and template override files from  `.yml` to `.yaml`
- update documentation and ignore rules to match the new filenames

Closes: #1, #2